### PR TITLE
Switch to raw docker commands

### DIFF
--- a/bin/.golang.sh
+++ b/bin/.golang.sh
@@ -12,3 +12,17 @@ if [ ! -f "$DOT_GOLANG" ]; then
 fi
 
 source "$DOT_GOLANG"
+
+
+# check for required vars
+
+if [ -z "$GOLANG_VERSION" ]; then
+	echo "GOLANG_VERSION must be set"
+	exit 1
+fi
+
+if [ -z "$GOLANG_VOLUMES_FROM" ]; then
+	echo "GOLANG_VOLUMES_FROM must be set"
+	exit 1
+fi
+

--- a/bin/.golang.sh
+++ b/bin/.golang.sh
@@ -1,0 +1,14 @@
+# vim: set filetype=sh :
+
+DOT_GOLANG="$(dirname $0)/../.golang"
+
+if [ ! -f "$DOT_GOLANG" ]; then
+	DOT_GOLANG="$(pwd)/.golang"
+fi
+
+if [ ! -f "$DOT_GOLANG" ]; then
+	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
+	exit 1
+fi
+
+source "$DOT_GOLANG"

--- a/bin/docker-golang-init
+++ b/bin/docker-golang-init
@@ -1,0 +1,35 @@
+#!/bin/bash
+# vim: set filetype=sh :
+set -e
+
+# docker-golang setup file creates the shared volume, .golang file and installs
+# some of the core binaries needed for our wrappers
+
+
+COMPOSE_YML="$(pwd)/docker-compose.yml"
+
+# check for a docker-compose.yml in the working dir, else use the one packaged
+# with docker-golang
+if [ ! -f  "${COMPOSE_YML}" ]; then
+	echo "No docker-compose.yml file (in \`$(pwd)\`)"
+	exit 1;
+fi
+
+if [ "${RESET}" = true ]; then
+	docker-compose rm -v golang
+fi
+
+# create the docker-compose `golang` volume
+docker-compose create golang
+
+# reset the .golang file
+echo > $(pwd)/.golang
+
+# TODO get GOLANG_VERSION from the docker-compose.yml
+echo "GOLANG_VERSION=1.7.5" >> $(pwd)/.golang
+echo "GOLANG_VOLUMES_FROM=$(docker-compose ps -q golang)" >> $(pwd)/.golang
+
+# install the necessary core binaries
+go get -u github.com/nsf/gocode
+go get -u github.com/golang/lint/golint
+

--- a/bin/go
+++ b/bin/go
@@ -1,13 +1,7 @@
 #!/bin/bash
 # vim: set filetype=sh :
 set -e
-
-if [ ! -f "$(pwd)/.golang" ]; then
-	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
-	exit 1
-fi
-
-source "$(pwd)/.golang"
+source "$(dirname $0)/.golang.sh"
 
 # replace pwd with the container's GOPATH (/go)
 # NOTE the expression here is because the actual path we call GO from may not

--- a/bin/go
+++ b/bin/go
@@ -2,16 +2,12 @@
 # vim: set filetype=sh :
 set -e
 
-COMPOSE_DIR="$(dirname $0)"
-COMPOSE_YML="$(pwd)/docker-compose.yml"
-
-# check for a docker-compose.yml in the working dir, else use the one packaged
-# with docker-golang
-if [ ! -f  "${COMPOSE_YML}" ]; then
-	COMPOSE_YML="${COMPOSE_DIR}/../docker-compose.yml"
+if [ ! -f "$(pwd)/.golang" ]; then
+	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
+	exit 1
 fi
 
-# TODO check for the go services, else default to the docker-golang compose yml
+source "$(pwd)/.golang"
 
 # replace pwd with the container's GOPATH (/go)
 # NOTE the expression here is because the actual path we call GO from may not
@@ -19,14 +15,12 @@ fi
 # called they are expanded to the symlink path
 WORKING_DIR="$(echo $(pwd) | sed -E "s#^(.+)/go/#/go/#")"
 
-if [ "${GO_DEBUG}" = true ]; then
-	echo "$WORKING_DIR" >> "$(dirname $0)/../go.log"
-	echo "$@" >> "$(dirname $0)/../go.log"
-fi
-
-docker-compose --file="${COMPOSE_YML}" run \
-	--no-deps \
+docker run \
 	--rm \
+	-i \
+	--volumes-from $GOLANG_VOLUMES_FROM \
+	-v $(pwd):$WORKING_DIR \
+	-v ~/.ssh:/root/ssh \
 	-w $WORKING_DIR \
-	go "$@"
+	--entrypoint go golang:$GOLANG_VERSION "$@"
 

--- a/bin/gocode
+++ b/bin/gocode
@@ -2,51 +2,32 @@
 # vim: set filetype=sh :
 set -e
 
+if [ ! -f "$(pwd)/.golang" ]; then
+	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
+	exit 1
+fi
+
+source $(pwd)/.golang
+
 # gocode wrapper
 #
 #     go get -u github.com/nsf/gocode
 #
 
-COMPOSE_DIR="$(dirname $0)"
-COMPOSE_YML="$(pwd)/docker-compose.yml"
-
-# check for a docker-compose.yml in the working dir, else use the one packaged
-# with docker-golang
-if [ ! -f  "${COMPOSE_YML}" ]; then
-	COMPOSE_YML="${COMPOSE_DIR}/../docker-compose.yml"
-fi
-
-# TODO check for the gocodec service, else default to the docker-golang compose
-# yml
-
 # parse the args and replace the GOPATH here with that of the docker
 # container's GOPATH
+WORKING_DIR="$(echo $(pwd) | sed -E "s#^(.+)/go/#/go/#")"
+
+# parse out our local GOPATH for the container's GOPATH in the gocode arguments
 args=$(echo "$@" | sed "s#$GOPATH#/go#")
 
-if [ "${GO_DEBUG}" = true ]; then
-	echo "$args" >> "$(dirname $0)/../gocode.log"
-fi
-
-# the --no-deps flag is required here, or the "Starting..." output breaks
-# autocomplete, or at least with YCM
-docker-compose --file="${COMPOSE_YML}" run \
-	--no-deps \
+docker run \
 	--rm \
-	-T \
-	--service-ports \
-	gocode ${args[@]}
-
-
-# A close docker raw equivalent. Note volumes-from is shared volume to for
-# shared go stuff. Leaving for reference. Was used to test speed
-#
-# docker run \
-# 	-i \
-# 	--volumes-from dockergolang_golang_1 \
-# 	-v ${GOPATH}/src:/go/src \
-# 	-v /tmp:/tmp \
-# 	-P \
-# 	-p 37373:37373 \
-# 	--entrypoint gocode \
-# 	golang:1.7.5 ${args[@]}
+	-i \
+	--volumes-from $GOLANG_VOLUMES_FROM \
+	-v $(pwd):$WORKING_DIR \
+	-v /tmp:/tmp \
+	-P \
+	-p 37373:37373 \
+	--entrypoint /go/bin/gocode golang:$GOLANG_VERSION ${args[@]}
 

--- a/bin/gocode
+++ b/bin/gocode
@@ -1,13 +1,7 @@
 #!/bin/bash
 # vim: set filetype=sh :
 set -e
-
-if [ ! -f "$(pwd)/.golang" ]; then
-	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
-	exit 1
-fi
-
-source $(pwd)/.golang
+source "$(dirname $0)/.golang.sh"
 
 # gocode wrapper
 #

--- a/bin/godoc
+++ b/bin/godoc
@@ -1,13 +1,7 @@
 #!/bin/bash
 # vim: set filetype=sh :
 set -e
-
-if [ ! -f "$(pwd)/.golang" ]; then
-	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
-	exit 1
-fi
-
-source "$(pwd)/.golang"
+source "$(dirname $0)/.golang.sh"
 
 # replace pwd with the container's GOPATH (/go)
 # NOTE the expression here is because the actual path we call GO from may not

--- a/bin/godoc
+++ b/bin/godoc
@@ -2,17 +2,12 @@
 # vim: set filetype=sh :
 set -e
 
-COMPOSE_DIR="$(dirname $0)"
-COMPOSE_YML="$(pwd)/docker-compose.yml"
-
-# check for a docker-compose.yml in the working dir, else use the one packaged
-# with docker-golang
-if [ ! -f  "${COMPOSE_YML}" ]; then
-	COMPOSE_YML="${COMPOSE_DIR}/../docker-compose.yml"
+if [ ! -f "$(pwd)/.golang" ]; then
+	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
+	exit 1
 fi
 
-# TODO check for the godoc services, else default to the docker-golang compose
-# yml
+source "$(pwd)/.golang"
 
 # replace pwd with the container's GOPATH (/go)
 # NOTE the expression here is because the actual path we call GO from may not
@@ -20,13 +15,11 @@ fi
 # called they are expanded to the symlink path
 WORKING_DIR="$(echo $(pwd) | sed -E "s#^(.+)/go/#/go/#")"
 
-if [ "${GO_DEBUG}" = true ]; then
-	echo "$@" >> "$(dirname $0)/../godoc.log" # debug
-fi
-
-docker-compose --file="${COMPOSE_YML}" run \
-	--no-deps \
+docker run \
 	--rm \
+	-i \
+	--volumes-from $GOLANG_VOLUMES_FROM \
+	-v $(pwd):$WORKING_DIR \
 	-w $WORKING_DIR \
-	godoc "$@"
+	--entrypoint godoc golang:$GOLANG_VERSION "$@"
 

--- a/bin/gofmt
+++ b/bin/gofmt
@@ -1,13 +1,7 @@
 #!/bin/bash
 # vim: set filetype=sh :
 set -e
-
-if [ ! -f "$(pwd)/.golang" ]; then
-	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
-	exit 1
-fi
-
-source "$(pwd)/.golang"
+source "$(dirname $0)/.golang.sh"
 
 docker run \
 	--rm \

--- a/bin/gofmt
+++ b/bin/gofmt
@@ -2,21 +2,17 @@
 # vim: set filetype=sh :
 set -e
 
-COMPOSE_DIR="$(dirname $0)"
-COMPOSE_YML="$(pwd)/docker-compose.yml"
-
-# check for a docker-compose.yml in the working dir, else use the one packaged
-# with docker-golang
-if [ ! -f  "${COMPOSE_YML}" ]; then
-	COMPOSE_YML="${COMPOSE_DIR}/../docker-compose.yml"
+if [ ! -f "$(pwd)/.golang" ]; then
+	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
+	exit 1
 fi
 
-# TODO check for the gofmt services, else default to the docker-golang compose
-# yml
+source "$(pwd)/.golang"
 
-# NOTE docker-compose allows TTY by default
-docker-compose --file="${COMPOSE_YML}" run \
-	--no-deps \
+docker run \
 	--rm \
-	gofmt "$@"
+	-t \
+	--volumes-from $GOLANG_VOLUMES_FROM \
+	-v /tmp:/tmp \
+	--entrypoint gofmt golang:$GOLANG_VERSION "$@"
 

--- a/bin/golint
+++ b/bin/golint
@@ -2,25 +2,21 @@
 # vim: set filetype=sh :
 set -e
 
+if [ ! -f "$(pwd)/.golang" ]; then
+	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
+	exit 1
+fi
+
+source "$(pwd)/.golang"
+
 # golint wrapper
 #
 #     go get -u github.com/golang/lint/golint
 #
 
-COMPOSE_DIR="$(dirname $0)"
-COMPOSE_YML="$(pwd)/docker-compose.yml"
-
-# check for a docker-compose.yml in the working dir, else use the one packaged
-# with docker-golang
-if [ ! -f  "${COMPOSE_YML}" ]; then
-	COMPOSE_YML="${COMPOSE_DIR}/../docker-compose.yml"
-fi
-
-# TODO check for the golint services, else default to the docker-golang compose
-# yml
-
-docker-compose --file="${COMPOSE_YML}" run \
-	--no-deps \
+docker run \
 	--rm \
-	golint "$@"
+	-t \
+	--volumes-from $GOLANG_VOLUMES_FROM \
+	--entrypoint /go/bin/golint golang:$GOLANG_VERSION "$@"
 

--- a/bin/golint
+++ b/bin/golint
@@ -1,13 +1,7 @@
 #!/bin/bash
 # vim: set filetype=sh :
 set -e
-
-if [ ! -f "$(pwd)/.golang" ]; then
-	echo "No \`.golang\` file (in \`$(pwd)\`), Run \`docker-golang-init\`"
-	exit 1
-fi
-
-source "$(pwd)/.golang"
+source "$(dirname $0)/.golang.sh"
 
 # golint wrapper
 #

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,16 @@ services:
   golang:
     image: "golang:1.7.5"
     volumes:
-      - ${GOPATH}/src:/go/src
+      # - ${GOPATH}/src:/go/src
+
       - /go/bin
       - /go/pkg
+      # https://forums.docker.com/t/docker-compose-is-extremely-slow/8690
+      # - /etc/resolv.conf:/etc/resolv.conf
+
+  # these services are no longe used, at least not via the wrappers as they are
+  # 3x slower than running via a raw docker comand
+  # Leaving the go service just in case
 
   go:
     extends:
@@ -18,42 +25,42 @@ services:
     # NOTE this is set in ./bin/go through the -w flag
     # working_dir: ${WORKING_DIR}
 
-  gofmt:
-    extends:
-      service: golang
-    volumes_from:
-      - golang
-    volumes:
-      - /tmp:/tmp
-    entrypoint: gofmt
+  # gofmt:
+  #   extends:
+  #     service: golang
+  #   volumes_from:
+  #     - golang
+  #   volumes:
+  #     - /tmp:/tmp
+  #   entrypoint: gofmt
 
-  godoc:
-    extends:
-      service: golang
-    volumes_from:
-      - golang
-    ports:
-      - "6060:6060"
-    entrypoint: godoc
+  # godoc:
+  #   extends:
+  #     service: golang
+  #   volumes_from:
+  #     - golang
+  #   ports:
+  #     - "6060:6060"
+  #   entrypoint: godoc
 
-  # install `go get -u github.com/nsf/gocode`
-  gocode:
-    extends:
-      service: golang
-    volumes_from:
-      - golang
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /tmp:/tmp
-    ports:
-      - "37373:37373"
-    entrypoint: /go/bin/gocode
+  # # install `go get -u github.com/nsf/gocode`
+  # gocode:
+  #   extends:
+  #     service: golang
+  #   volumes_from:
+  #     - golang
+  #   volumes:
+  #     - /var/run/docker.sock:/var/run/docker.sock
+  #     - /tmp:/tmp
+  #   ports:
+  #     - "37373:37373"
+  #   entrypoint: /go/bin/gocode
 
-  # install `go get -u github.com/golang/lint/golint`
-  golint:
-    extends:
-      service: golang
-    volumes_from:
-      - golang
-    entrypoint: /go/bin/golint
+  # # install `go get -u github.com/golang/lint/golint`
+  # golint:
+  #   extends:
+  #     service: golang
+  #   volumes_from:
+  #     - golang
+  #   entrypoint: /go/bin/golint
 


### PR DESCRIPTION
This PR contains a switch to using raw docker commands instead of docker-compose. `docker-compose run` is 3-5x slower than using the `docker run`. Even when with `--no-deps`, the lag time is just too long.

But, because docker-compose is still a standard for projects, particular for easing docker in the CI pipelines, we will use them to create the standard shared volumes for the project and use those in our wrappers through `env vars` to link the proper `--volumes-from` and setting the proper `GOLANG_VERSION` for a given project.

`docker-golang-init`, introduced here, will setup these shared files as well as a `.golang` file which will house the `env vars` for the `GOLANG_VERSION` and the `GOLANG_VOLUMES_FROM` (shared volume) for the current project.